### PR TITLE
Add S3 support

### DIFF
--- a/__tests__/unit/__mocks__.ts
+++ b/__tests__/unit/__mocks__.ts
@@ -34,3 +34,5 @@ export const record: SQSRecord = {
   eventSourceARN: 'arn:aws:sqs:us-east-1:123456789012:MyQueue',
   awsRegion: 'us-east-1',
 }
+
+export const uuid = 'aaaaa-uuuuu-uuuuu-iiiii-ddddd'

--- a/__tests__/unit/handlers/sqs-payload-processor.test.ts
+++ b/__tests__/unit/handlers/sqs-payload-processor.test.ts
@@ -1,26 +1,36 @@
-import { emailData, record } from '../__mocks__'
+import { emailData, record, uuid } from '../__mocks__'
 import * as sqsPayloadProcessor from '../../../src/handlers/sqs-payload-processor'
 import { processSingleMessage, sqsPayloadProcessorHandler } from '../../../src/handlers/sqs-payload-processor'
 
+const mockDeleteContentFromS3 = jest.fn()
+const mockFetchContentFromS3 = jest.fn()
+jest.mock('../../../src/services/s3', () => ({
+  deleteContentFromS3: (uuid) => mockDeleteContentFromS3(uuid),
+  fetchContentFromS3: (uuid) => mockFetchContentFromS3(uuid),
+}))
 const mockGenerateEmailFromData = jest.fn()
 const mockSendRawEmail = jest.fn()
-jest.mock('@services/ses', () => ({
+jest.mock('../../../src/services/ses', () => ({
   generateEmailFromData: (data) => mockGenerateEmailFromData(data),
   sendRawEmail: (message) => mockSendRawEmail(message),
 }))
 const mockGetDataFromRecord = jest.fn()
-jest.mock('@util/message-processing', () => ({
+jest.mock('../../../src/util/message-processing', () => ({
   getDataFromRecord: (record) => mockGetDataFromRecord(record),
 }))
 
 describe('sqs-payload-processor', () => {
-  const expectedBuffer = Buffer.from('hello!')
+  beforeAll(() => {
+    mockGetDataFromRecord.mockResolvedValue({ uuid })
+  })
 
   describe('processSingleMessage', () => {
+    const expectedBuffer = Buffer.from('hello!')
+
     beforeAll(() => {
+      mockFetchContentFromS3.mockResolvedValue(emailData)
       mockGenerateEmailFromData.mockResolvedValue(expectedBuffer)
       mockSendRawEmail.mockResolvedValue(undefined)
-      mockGetDataFromRecord.mockResolvedValue({ email: emailData })
     })
 
     test('expect getDataFromRecord to be called with input', async () => {
@@ -28,7 +38,12 @@ describe('sqs-payload-processor', () => {
       expect(mockGetDataFromRecord).toHaveBeenCalledWith(record)
     })
 
-    test('expect mockGenerateEmailFromData to be called with output from getDataFromRecord', async () => {
+    test('expect fetchContentFromS3 to be called with output from getDataFromRecord', async () => {
+      await processSingleMessage(record)
+      expect(mockFetchContentFromS3).toHaveBeenCalledWith(uuid)
+    })
+
+    test('expect mockGenerateEmailFromData to be called with output from fetchContentFromS3', async () => {
       await processSingleMessage(record)
       expect(mockGenerateEmailFromData).toHaveBeenCalledWith(emailData)
     })
@@ -37,15 +52,22 @@ describe('sqs-payload-processor', () => {
       await processSingleMessage(record)
       expect(mockSendRawEmail).toHaveBeenCalledWith(expectedBuffer)
     })
+
+    test('expect deleteContentFromS3 to be called', async () => {
+      await processSingleMessage(record)
+      expect(mockDeleteContentFromS3).toHaveBeenCalledWith(uuid)
+    })
   })
 
   describe('sqsPayloadProcessorHandler', () => {
-    const event = { Records: [record] }
+    const record2 = { ...record, messageId: '8765rfg-76tfg-hui8yt-7trdf-gui567yfdf' }
+    const event = { Records: [record, record2] }
     const processSingleMessageSpy = jest.spyOn(sqsPayloadProcessor, 'processSingleMessage')
 
     test('expect processSingleMessage to be called for each record', async () => {
-      await sqsPayloadProcessorHandler(event)
+      await sqsPayloadProcessorHandler(event, undefined, undefined)
       expect(processSingleMessageSpy).toHaveBeenCalledWith(record)
+      expect(processSingleMessageSpy).toHaveBeenCalledWith(record2)
     })
   })
 })

--- a/__tests__/unit/services/s3.test.ts
+++ b/__tests__/unit/services/s3.test.ts
@@ -1,11 +1,15 @@
 import { S3 } from 'aws-sdk'
 
+import { uuid } from '../__mocks__'
 import { emailBucket } from '../../../src/config'
-import { getS3Object } from '../../../src/services/s3'
+import * as s3Module from '../../../src/services/s3'
+import { deleteContentFromS3, deleteS3Object, fetchContentFromS3, getS3Object } from '../../../src/services/s3'
 
+const mockDeleteObject = jest.fn()
 const mockGetObject = jest.fn()
 jest.mock('aws-sdk', () => ({
   S3: jest.fn(() => ({
+    deleteObject: (params: S3.Types.DeleteObjectRequest) => ({ promise: () => mockDeleteObject(params) }),
     getObject: (params: S3.Types.GetObjectRequest) => ({ promise: () => mockGetObject(params) }),
   })),
 }))
@@ -16,6 +20,34 @@ jest.mock('../../../src/util/error-handling', () => ({
 
 describe('S3', () => {
   const key = 'prefix/key'
+
+  describe('fetchContentFromS3', () => {
+    const expectedResult = { Hello: 'world' }
+    const mockGetS3Object = jest.spyOn(s3Module, 'getS3Object')
+
+    beforeEach(() => {
+      mockGetS3Object.mockResolvedValueOnce(JSON.stringify(expectedResult))
+    })
+
+    test('expect correct key passed to getS3Object', async () => {
+      await fetchContentFromS3(uuid)
+      expect(mockGetS3Object).toHaveBeenCalledWith(`queue/${uuid}`)
+    })
+
+    test('expect parsed JSON returned', async () => {
+      const result = await fetchContentFromS3(uuid)
+      expect(result).toEqual(expectedResult)
+    })
+  })
+
+  describe('deleteContentFromS3', () => {
+    const mockDeleteS3Object = jest.spyOn(s3Module, 'deleteS3Object')
+
+    test('expect correct key passed to getS3Object', async () => {
+      await deleteContentFromS3(uuid)
+      expect(mockDeleteS3Object).toHaveBeenCalledWith(`queue/${uuid}`)
+    })
+  })
 
   describe('getS3Object', () => {
     const expectedObject = 'thar-be-values-here'
@@ -44,6 +76,17 @@ describe('S3', () => {
       mockGetObject.mockRejectedValueOnce({})
       const result = await getS3Object(key)
       expect(result).toEqual('')
+    })
+  })
+
+  describe('deleteS3Object', () => {
+    beforeAll(() => {
+      mockDeleteObject.mockResolvedValue(undefined)
+    })
+
+    test('expect key passed to S3 as object', async () => {
+      await deleteS3Object(key)
+      expect(mockDeleteObject).toHaveBeenCalledWith({ Bucket: emailBucket, Key: key })
     })
   })
 })

--- a/__tests__/unit/services/s3.test.ts
+++ b/__tests__/unit/services/s3.test.ts
@@ -1,0 +1,49 @@
+import { S3 } from 'aws-sdk'
+
+import { emailBucket } from '../../../src/config'
+import { getS3Object } from '../../../src/services/s3'
+
+const mockGetObject = jest.fn()
+jest.mock('aws-sdk', () => ({
+  S3: jest.fn(() => ({
+    getObject: (params: S3.Types.GetObjectRequest) => ({ promise: () => mockGetObject(params) }),
+  })),
+}))
+
+jest.mock('../../../src/util/error-handling', () => ({
+  handleErrorWithDefault: (value) => () => value,
+}))
+
+describe('S3', () => {
+  const key = 'prefix/key'
+
+  describe('getS3Object', () => {
+    const expectedObject = 'thar-be-values-here'
+
+    beforeAll(() => {
+      mockGetObject.mockResolvedValue({ Body: expectedObject })
+    })
+
+    test('expect key passed to S3 as object', async () => {
+      await getS3Object(key)
+      expect(mockGetObject).toHaveBeenCalledWith({ Bucket: emailBucket, Key: key })
+    })
+
+    test('expect expectedObject as result', async () => {
+      const result = await getS3Object(key)
+      expect(result).toEqual(expectedObject)
+    })
+
+    test('expect empty result when body missing', async () => {
+      mockGetObject.mockResolvedValueOnce({})
+      const result = await getS3Object(key)
+      expect(result).toEqual('')
+    })
+
+    test('expect empty result when promise rejects', async () => {
+      mockGetObject.mockRejectedValueOnce({})
+      const result = await getS3Object(key)
+      expect(result).toEqual('')
+    })
+  })
+})

--- a/events/event-sqs.json
+++ b/events/event-sqs.json
@@ -8,8 +8,7 @@
           "StringValue": "sqs-payload-logger"
         }
       },
-      "MessageBody": "This message was sent by the sqs-payload-logger Lambda function",
-      "body": "{\"email\":{\"from\":\"do-not-reply@bowland.link\",\"sender\":\"do-not-reply@bowland.link\",\"to\":[\"david@bowland.link\"],\"replyTo\":\"dave@bowland.link\",\"references\":[],\"subject\":\"Hi there!\",\"text\":\"Hello, world\",\"html\":\"<p>Hello, world</p>\",\"headers\":{\"From\":\"do-not-reply@bowland.link\"}}}",
+      "body": "{ \"uuid\": \"47fa66c0-626e-11ec-824b-3b5ff6254c28\" }",
       "QueueUrl": "SQS_QUEUE_URL"
     }
   ]

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "clean": "rm -rf dist coverage && NODE_ENV=test npm ci",
     "lint": "prettier --write . && eslint --fix . --resolve-plugins-relative-to .",
     "prepare": "if [ \"$HUSKY\" != \"0\" ]; then husky install ; fi",
-    "start": "tsc && HUSKY=0 sam build && sam local invoke --event events/event-sqs.json",
+    "start": "npm run build && npm run quick-start",
+    "quick-start": "tsc && HUSKY=0 sam build && EMAIL_BUCKET=emails-dbowland EMAIL_REGION=us-east-1 sam local invoke --event events/event-sqs.json",
     "test": "npm run lint && jest --colors"
   },
   "lint-staged": {

--- a/src/handlers/sqs-payload-processor.ts
+++ b/src/handlers/sqs-payload-processor.ts
@@ -1,6 +1,7 @@
 import { SQSEvent, SQSHandler, SQSRecord } from 'aws-lambda'
 
 import { generateEmailFromData, sendRawEmail } from '../services/ses'
+import { handleErrorNoDefault } from '../util/error-handling'
 import { getDataFromRecord } from '../util/message-processing'
 
 /* Queue processing */
@@ -8,9 +9,8 @@ import { getDataFromRecord } from '../util/message-processing'
 export const processSingleMessage = (record: SQSRecord) =>
   getDataFromRecord(record).then((data) => generateEmailFromData(data.email).then((email) => sendRawEmail(email)))
 
-export const sqsPayloadProcessorHandler: SQSHandler = (event: SQSEvent) => {
-  // All log statements are written to CloudWatch by default. For more information, see
-  // https://docs.aws.amazon.com/lambda/latest/dg/nodejs-prog-model-logging.html
-  console.info(JSON.stringify(event))
-  return Promise.all(event.Records.map((record) => exports.processSingleMessage(record))).then(() => undefined)
-}
+export const sqsPayloadProcessorHandler: SQSHandler = (event: SQSEvent) =>
+  event.Records.reduce(
+    (previous, record) => previous.then(() => exports.processSingleMessage(record).catch(handleErrorNoDefault())),
+    Promise.resolve(undefined)
+  )

--- a/src/services/s3.ts
+++ b/src/services/s3.ts
@@ -1,0 +1,15 @@
+import { S3 } from 'aws-sdk'
+
+import { emailBucket } from '../config'
+import { handleErrorWithDefault } from '../util/error-handling'
+
+const s3 = new S3({ apiVersion: '2006-03-01' })
+
+/* Get */
+
+export const getS3Object = (key: string): Promise<string> =>
+  s3
+    .getObject({ Bucket: emailBucket, Key: key })
+    .promise()
+    .then((result) => (result.Body ?? '') as string)
+    .catch(handleErrorWithDefault(''))

--- a/src/services/s3.ts
+++ b/src/services/s3.ts
@@ -2,8 +2,15 @@ import { S3 } from 'aws-sdk'
 
 import { emailBucket } from '../config'
 import { handleErrorWithDefault } from '../util/error-handling'
+import { EmailData } from '../util/message-processing'
 
 const s3 = new S3({ apiVersion: '2006-03-01' })
+
+export const fetchContentFromS3 = (uuid: string): Promise<EmailData> =>
+  exports.getS3Object(`queue/${uuid}`).then(JSON.parse)
+
+export const deleteContentFromS3 = (uuid: string): Promise<S3.DeleteObjectOutput> =>
+  exports.deleteS3Object(`queue/${uuid}`)
 
 /* Get */
 
@@ -13,3 +20,8 @@ export const getS3Object = (key: string): Promise<string> =>
     .promise()
     .then((result) => (result.Body ?? '') as string)
     .catch(handleErrorWithDefault(''))
+
+/* Delete */
+
+export const deleteS3Object = (key: string): Promise<S3.DeleteObjectOutput> =>
+  s3.deleteObject({ Bucket: emailBucket, Key: key }).promise()

--- a/src/util/message-processing.ts
+++ b/src/util/message-processing.ts
@@ -7,7 +7,7 @@ export interface EmailData {
 }
 
 export interface MessageData {
-  email?: EmailData
+  uuid?: string
 }
 
 /* Body */

--- a/template.yaml
+++ b/template.yaml
@@ -51,9 +51,12 @@ Resources:
       Policies:
         # Give Lambda basic execution Permission
         - AWSLambdaBasicExecutionRole
-        # Grant access to SQS queue
-        - SQSPollerPolicy:
-            QueueName: !GetAtt SimpleQueue.QueueName
+        # Grant access to S3 bucket
+        - S3CrudPolicy:
+            BucketName: emails-dbowland
         # Grant access to SES identity
         - SESCrudPolicy:
             IdentityName: bowland.link
+        # Grant access to SQS queue
+        - SQSPollerPolicy:
+            QueueName: !GetAtt SimpleQueue.QueueName


### PR DESCRIPTION
SQS max size is 256kb, but an email consists of the HTML contents, the text contents, and attachments. Switch to using S3 to store emails and SQS as a marker for those emails.